### PR TITLE
Add dynamic type casting support to GetInputValue

### DIFF
--- a/Assets/Nodes/Converters/Converter.cs
+++ b/Assets/Nodes/Converters/Converter.cs
@@ -1,0 +1,12 @@
+
+public interface Converter {
+    object Convert(object obj);
+}
+
+public abstract class Converter<T1, T2> : Converter {
+    protected abstract T2 Convert(T1 obj);
+
+    public virtual object Convert(object obj) {
+        return Convert((T1) obj);
+    }
+}

--- a/Assets/Nodes/Converters/Converter.cs.meta
+++ b/Assets/Nodes/Converters/Converter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd952ba31b5e66544bac3300acacc543
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nodes/Converters/IntToFloatConverter.cs
+++ b/Assets/Nodes/Converters/IntToFloatConverter.cs
@@ -1,0 +1,5 @@
+public class IntToFloatConverter : Converter<int, float> {
+    protected override float Convert(int obj) {
+        return obj;
+    }
+}

--- a/Assets/Nodes/Converters/IntToFloatConverter.cs.meta
+++ b/Assets/Nodes/Converters/IntToFloatConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e16703fc29e245f4baacc0f718dc1161
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nodes/Nodes/Node.cs
+++ b/Assets/Nodes/Nodes/Node.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+
+public abstract class Node : XNode.Node {
+    private static readonly Dictionary<Type, object> ConverterCache = new Dictionary<Type, object>();
+
+    /// <summary>
+    /// Intelligent version of the original that calls internal converters
+    /// for dynamic type casting (e.g. int -> float).
+    ///
+    /// This also allows converting more complex types like Transforms to Quaternions.
+    /// </summary>
+    /// <param name="fieldName">Field name of requested input port</param>
+    /// <param name="fallback">If no ports are connected, this value will be returned</param>
+    public new T GetInputValue<T>(string fieldName, T fallback = default) {
+        var port = GetPort(fieldName);
+
+        if (port == null || !port.IsConnected) {
+            return fallback;
+        }
+
+        var value = port.GetInputValue();
+
+        if (value is T cast) {
+            return cast;
+        }
+
+#if UNITY_2019_2_OR_NEWER
+        return TryConvertValue(value, out T converted) ? converted : fallback;
+    }
+
+    private static bool TryConvertValue<T>(object input, out T output) {
+        var type = typeof(Converter<,>).MakeGenericType(input.GetType(), typeof(T));
+
+        if (!ConverterCache.TryGetValue(type, out var instance)) {
+            var converters = TypeCache.GetTypesDerivedFrom(type);
+
+            if (converters.Count <= 0) {
+                output = default;
+                return false;
+            }
+
+            instance = Activator.CreateInstance(converters[0]);
+            ConverterCache[type] = instance;
+        }
+
+        var val = ((Converter) instance).Convert(input);
+        output = (T) val;
+        return true;
+#else
+        return fallback;
+#endif
+    }
+}
+

--- a/Assets/Nodes/Nodes/Node.cs.meta
+++ b/Assets/Nodes/Nodes/Node.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eddd589b85964e8db0ecd39ee8f70d5f
+timeCreated: 1581027339


### PR DESCRIPTION
This adds an intelligent version of the original to call internal
converters. This also allows converting more complex types like
Transforms to Quaternions (as long as there is a converter for that).

Only works in 2019.2+ since the TypeCache is being used to speed up
any type lookups (native C# assembly diving would be too much of a
performance hit).

![image](https://user-images.githubusercontent.com/429147/73988455-11e3ce00-4943-11ea-9a8e-7ba0ef5c7189.png)
